### PR TITLE
Fix Lipidmaps URL. Relates to #3

### DIFF
--- a/LipidFinder/PeakFilter/FalseDiscoveryRate.py
+++ b/LipidFinder/PeakFilter/FalseDiscoveryRate.py
@@ -26,8 +26,8 @@ from requests_toolbelt.multipart.encoder import MultipartEncoder
 from LipidFinder._py3k import StringIO, range
 
 
-#LIPIDMAPS_URL = 'http://www.lipidmaps.org/tools/ms/py_bulk_search.php'
-LIPIDMAPS_URL = 'http://lipidmaps-dev.babraham.ac.uk/tools/ms/py_bulk_search.php'
+LIPIDMAPS_URL = 'https://www.lipidmaps.org/tools/ms/py_bulk_search.php'
+#LIPIDMAPS_URL = 'https://dev.lipidmaps.org/tools/ms/py_bulk_search.php'
 # Maximum number of m/z values to send at once to LIPID MAPS
 BATCH_SIZE = 500
 

--- a/LipidFinder/PeakFilter/__init__.py
+++ b/LipidFinder/PeakFilter/__init__.py
@@ -226,8 +226,8 @@ def peak_filter(data, parameters, dst='', verbose=False):
                        "{0:.2%}").format(fdrValue)
         except ValueError as e:
             message = 'ValueError: ' + e.args[0]
-        except Exception:
-            pass
+        except Exception as oe:
+            message = 'OtherError: ' + oe.args[0]
         logger.info(message)
     stepNum = _update_status(data, stepDst, verbose, stepNum)
     # Create summary CSV file from the processed dataframe


### PR DESCRIPTION
This should fix both the reporting error and the incorrectly referenced lipidmaps server.  It also switches the protocol to https which will be required for all future interactions.